### PR TITLE
Remove duplicate method invocation fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,15 +7,6 @@ class ServerlessPluginWebpack {
   constructor (serverless, options) {
     this.serverless = serverless
     this.options = options
-
-    this.commands = {
-      deploy: {
-        lifecycleEvents: [
-          'initialize'
-        ]
-      }
-    }
-
     this.hooks = {
       'before:deploy:initialize': this.bundle.bind(this)
     }


### PR DESCRIPTION
Registering the plugin on the deploy command and hook caused the plugin to be executed twice